### PR TITLE
Switch from `poetry` to `poetry-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,5 @@ pytest = "^6.2.2"
 readmdict = "readmdict.__main__:main"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This change makes `python -m build --no-isolation --wheel` work. Required for downstream packaging (see https://github.com/NixOS/nixpkgs/pull/257437).